### PR TITLE
feat(build): allow optional service method return overrides

### DIFF
--- a/tonic-build/README.md
+++ b/tonic-build/README.md
@@ -40,6 +40,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
    Ok(())
 }
 ```
+
+### Override service method return values
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+   tonic_build::configure()
+        .service_return_overrides(tonic_build::ServiceReturnOverrideMap::from([
+            (String::from("Echo.unary_echo"), ServiceReturnOverride::None), // implied if no mapping is made for the service. trait method implementation therefore required.
+            (String::from("Echo.server_streaming_echo"), ServiceReturnOverride::OkDefault), // return the default value for the response message.
+            (String::from("Echo.client_streaming_echo"), ServiceReturnOverride::ErrUnimplemented), // return the unimplemented error status.
+            // any other service not mapped here will require an explicit trait method implementation.
+        ]))
+        .compile(
+            &["proto/echo/echo.proto"],
+            &["proto/echo"],
+        )?;
+   Ok(())
+}
+```
 See [more examples here](https://github.com/hyperium/tonic/tree/master/examples)
 
 ### Google APIs example

--- a/tonic-build/src/code_gen.rs
+++ b/tonic-build/src/code_gen.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 
-use crate::{Attributes, Service};
+use crate::{prost::ServiceReturnOverrideMap, Attributes, Service};
 
 /// Builder for the generic code generation of server and clients.
 #[derive(Debug)]
@@ -12,7 +12,7 @@ pub struct CodeGenBuilder {
     attributes: Attributes,
     build_transport: bool,
     disable_comments: HashSet<String>,
-    default_impl: bool
+    service_return_overrides: ServiceReturnOverrideMap,
 }
 
 impl CodeGenBuilder {
@@ -59,8 +59,11 @@ impl CodeGenBuilder {
     }
 
     /// Enable or disable returning automatic unimplemented gRPC error code for generated traits.
-    pub fn default_impl(&mut self, default_impl: bool) -> &mut Self {
-        self.default_impl = default_impl;
+    pub fn service_return_overrides(
+        &mut self,
+        service_return_overrides: ServiceReturnOverrideMap,
+    ) -> &mut Self {
+        self.service_return_overrides = service_return_overrides;
         self
     }
 
@@ -92,7 +95,7 @@ impl CodeGenBuilder {
             self.compile_well_known_types,
             &self.attributes,
             &self.disable_comments,
-            self.default_impl
+            &self.service_return_overrides,
         )
     }
 }
@@ -105,7 +108,7 @@ impl Default for CodeGenBuilder {
             attributes: Attributes::default(),
             build_transport: true,
             disable_comments: HashSet::default(),
-            default_impl: false
+            service_return_overrides: ServiceReturnOverrideMap::default(),
         }
     }
 }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -85,7 +85,7 @@ mod prost;
 
 #[cfg(feature = "prost")]
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
-pub use prost::{compile_protos, configure, Builder};
+pub use prost::{compile_protos, configure, Builder, ServiceReturnOverrideMap};
 
 pub mod manual;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As per my comments:
- Feature request: https://github.com/hyperium/tonic/pull/1344#discussion_r1168034460
- Motivation: https://github.com/tokio-rs/prost/issues/844#issuecomment-1510479430

It would be nice to have configurable return values.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

> **Warning**: 
> - There are no tests (yet), and I have not run this, only run `cargo build`.
> - We might need to consider adding proto package names to the mapping in case of duplicate service names in different packages.
> - I have mostly copied existing patterns, so some signatures contain references even though copies/clones are occurring.
> - Docs and variable/method names could use some massaging.

Here's an example of the feature in use (I have not yet tested it):

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
   tonic_build::configure()
        .service_return_overrides(tonic_build::prost::ServiceReturnOverrideMap::from([
            (String::from("Echo.unary_echo"), ServiceReturnOverride::None), // implied if no mapping is made for the service. trait method implementation therefore required.
            (String::from("Echo.server_streaming_echo"), ServiceReturnOverride::OkDefault), // return the default value for the response message.
            (String::from("Echo.client_streaming_echo"), ServiceReturnOverride::ErrUnimplemented), // return the unimplemented error status.
            // any other service not mapped here will require an explicit trait method implementation.
        ]))
        .compile(
            &["proto/echo/echo.proto"],
            &["proto/echo"],
        )?;
   Ok(())
}
```

_I did consider another variant to allow custom tonic::Status errors to be returned, but this was a little tricky without importing `tonic` into `tonic-build` - only for access to that single `enum`. It can be added later if the need surfaces._